### PR TITLE
Use Raw mode when getting json content from a file

### DIFF
--- a/Scripts/Update-OctopusVariableSet.ps1
+++ b/Scripts/Update-OctopusVariableSet.ps1
@@ -51,7 +51,7 @@ function Update-OctopusVariableSet
                 Throw "File not found: $file"
             }
     
-            $JSON = Get-Content $file
+            $JSON = Get-Content $file -Raw
 
             Try{
                 Write-Verbose "[$($MyInvocation.MyCommand)] Importing variables as JSON from: $file"


### PR DESCRIPTION
To prevent the following error when the json is split over several lines

```ConvertFrom-Json : Invalid object passed in, ':' or '}' expected.```