### PR TITLE
Fixed issue with running function remotely

### DIFF
--- a/Scripts/Get-OctopusTargetDiscoveryInfo.ps1
+++ b/Scripts/Get-OctopusTargetDiscoveryInfo.ps1
@@ -49,7 +49,7 @@ function Get-OctopusTargetDiscoveryInfo
 
         Try{
 
-            $discover = ((Invoke-WebRequest $url -Headers $c.header).content | ConvertFrom-Json).endpoint
+            $discover = ((Invoke-WebRequest $url -Headers $c.header -UseBasicParsing).content | ConvertFrom-Json).endpoint
         }
         Catch{
             Write-Error "Unable to make a connection to $url. Error was: `n $_"


### PR DESCRIPTION
Unable to make a connection to <URL>. Error was: 
 The response content cannot be parsed because the Internet Explorer engine is not available, or Internet Explorer's first-launch configuration is not complete. Specify the UseBasicParsing parameter and try again.