### PR TITLE
Updated Octopus.Client Package Version.

### DIFF
--- a/Octoposh/Octoposh.csproj
+++ b/Octoposh/Octoposh.csproj
@@ -55,8 +55,8 @@
     <Reference Include="NuGet.Versioning, Version=4.3.0.4, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
       <HintPath>..\packages\NuGet.Versioning.4.3.0-preview4\lib\net45\NuGet.Versioning.dll</HintPath>
     </Reference>
-    <Reference Include="Octopus.Client, Version=4.22.0.0, Culture=neutral, processorArchitecture=MSIL">
-      <HintPath>..\packages\Octopus.Client.4.22.0\lib\net45\Octopus.Client.dll</HintPath>
+    <Reference Include="Octopus.Client, Version=4.31.5.0, Culture=neutral, processorArchitecture=MSIL">
+      <HintPath>..\packages\Octopus.Client.4.31.5\lib\net45\Octopus.Client.dll</HintPath>
     </Reference>
     <Reference Include="System" />
     <Reference Include="System.ComponentModel.DataAnnotations" />

--- a/Octoposh/packages.config
+++ b/Octoposh/packages.config
@@ -4,7 +4,7 @@
   <package id="Newtonsoft.Json" version="10.0.3" targetFramework="net461" />
   <package id="NuGet.Core" version="2.14.0" targetFramework="net452" />
   <package id="NuGet.Versioning" version="4.3.0-preview4" targetFramework="net461" />
-  <package id="Octopus.Client" version="4.22.0" targetFramework="net461" />
+  <package id="Octopus.Client" version="4.31.5" targetFramework="net461" />
   <package id="System.Management.Automation" version="6.1.7601.17515" targetFramework="net452" />
   <package id="System.Net.Http" version="4.3.2" targetFramework="net452" />
   <package id="XmlDoc2CmdletDoc" version="0.2.7" targetFramework="net452" developmentDependency="true" />


### PR DESCRIPTION
-Updated the Octopus.Client package to v4.31.5.  This resolves an issue where Octoposh is incompatible with 4.1.X and 2018.X versions of Octopus Deploy.