### PR TITLE
Correct case for octoposh.dll for use on case sensitive file systems

### DIFF
--- a/Octoposh/Octoposh.psd1
+++ b/Octoposh/Octoposh.psd1
@@ -1,7 +1,7 @@
 @{
 #
 # Script module or binary module file associated with this manifest.
-RootModule = 'OctoPosh.dll'
+RootModule = 'Octoposh.dll'
 
 # Version number of this module.
 ModuleVersion = '0.0.0.0'


### PR DESCRIPTION
When installing the Octoposh module on a case sensitive file system (such as in a Linux VM or WSL) the following error occurs:

```
Import-Module : The module to process 'OctoPosh.dll', listed in field 'ModuleToProcess/RootModule' of module manifest '/root/.local/share/powershell/Modules/Octoposh/0.6.11/Octoposh.psd1' was not processed because no valid module was found in any module directory.
```

This is because the correct filename is `Octoposh.dll` not `OctoPosh.dll`.

This PR fixes the `RootModule` to have the correct casing.